### PR TITLE
feat(chart): support existingSecret for password and URL via secretKeys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,43 @@ jobs:
       - name: Lint chart
         run: helm lint chart/ --set database.host=lint --set database.password=lint
 
-      - name: Template (standard)
-        run: helm template kora chart/ --set database.host=test --set database.password=test > /dev/null
+      - name: Template (component — inline password)
+        run: |
+          out=$(helm template kora chart/ --set database.host=test --set database.password=test)
+          grep -q 'kind: Secret' <<<"$out"
+          grep -q 'name: kora-db' <<<"$out"
+          grep -q 'key: "password"' <<<"$out"
+          grep -q 'name: DB_HOST' <<<"$out"
 
-      - name: Template (existingSecret)
-        run: helm template kora chart/ --set database.existingSecret=my-secret > /dev/null
+      - name: Template (component — existing secret)
+        run: |
+          out=$(helm template kora chart/ --set database.host=test --set database.existingSecret=my-secret --set database.secretKeys.password=db-password)
+          ! grep -q 'kind: Secret' <<<"$out"
+          grep -q 'name: my-secret' <<<"$out"
+          grep -q 'key: "db-password"' <<<"$out"
+
+      - name: Template (URL — inline)
+        run: |
+          out=$(helm template kora chart/ --set database.url=postgres://u:p@h/d)
+          grep -q 'kind: Secret' <<<"$out"
+          grep -q 'name: DATABASE_URL' <<<"$out"
+          ! grep -q 'name: DB_HOST' <<<"$out"
+
+      - name: Template (URL — existing secret)
+        run: |
+          out=$(helm template kora chart/ --set database.existingSecret=my-secret --set database.secretKeys.url=DATABASE_URL)
+          ! grep -q 'kind: Secret' <<<"$out"
+          grep -q 'name: my-secret' <<<"$out"
+          grep -q 'key: "DATABASE_URL"' <<<"$out"
+
+      - name: Template (mutually exclusive — must fail)
+        run: |
+          assert_fail() {
+            local msg=$1
+            shift
+            out=$(helm template kora chart/ "$@" 2>&1) && { echo "expected fail, got success"; echo "$out"; exit 1; }
+            grep -q "$msg" <<<"$out" || { echo "expected message '$msg', got:"; echo "$out"; exit 1; }
+          }
+          assert_fail 'mutually exclusive' --set database.url=postgres://u:p@h/d --set database.existingSecret=my-secret
+          assert_fail 'mutually exclusive' --set database.host=h --set database.password=p --set database.existingSecret=my-secret
+          assert_fail 'mutually exclusive' --set database.url=postgres://u:p@h/d --set database.password=p

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,14 +684,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "figment"
 version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
 dependencies = [
  "atomic",
+ "parking_lot",
  "pear",
  "serde",
+ "tempfile",
  "uncased",
  "version_check",
 ]
@@ -1412,6 +1420,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
  "uuid",
 ]
 
@@ -1463,6 +1472,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2343,6 +2358,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3017,6 +3045,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3367,6 +3408,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ tokio = { version = "1.52.1", features = ["full"] }
 tower-http = { version = "0.6.8", features = ["set-header"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["json", "env-filter"] }
+urlencoding = "2.1"
 uuid = { version = "1.23.1", features = ["v4", "serde"] }
 
 [profile.release]
@@ -32,6 +33,7 @@ opt-level = "s"
 strip = true
 
 [dev-dependencies]
+figment = { version = "0.10.19", features = ["env", "test"] }
 reqwest = { version = "0.13.2", features = ["json"] }
 serial_test = { version = "3.4.0", features = ["file_locks"] }
 tokio-test = "0.4.5"

--- a/chart/README.md
+++ b/chart/README.md
@@ -18,9 +18,14 @@ helm install kora oci://ghcr.io/romderful/kora/charts/kora \
 
 ## Database Configuration
 
-Three modes — pick one:
+Two channels:
 
-### Host and password
+- **Component mode** (default) — `host` / `port` / `user` / `database` plain in values, `password` always mounted via `secretKeyRef` (auto-Secret or `existingSecret`).
+- **URL mode** — full `DATABASE_URL` mounted via `secretKeyRef` (auto-Secret or `existingSecret`). Triggered by setting `database.url` or `database.secretKeys.url` (with `existingSecret`). Components are ignored.
+
+The auto-Secret base64-encodes the value but does not encrypt it — never commit `helm template` output to git.
+
+### Component mode — inline
 
 ```bash
 helm install kora oci://ghcr.io/romderful/kora/charts/kora \
@@ -28,19 +33,34 @@ helm install kora oci://ghcr.io/romderful/kora/charts/kora \
   --set database.password=secret
 ```
 
-### Full URL (for SSL, custom params)
+### Component mode — password from existing Secret
+
+Suits ExternalSecrets Operator, CloudNativePG, AWS RDS via ESO, Vault, etc.
 
 ```bash
 helm install kora oci://ghcr.io/romderful/kora/charts/kora \
-  --set database.url="postgres://kora:secret@postgres:5432/kora?sslmode=require"
+  --set database.host=postgres.example.com \
+  --set database.existingSecret=kora-db-credentials
 ```
 
-### Existing secret (recommended for production)
+Override the key with `--set database.secretKeys.password=db-password` if it isn't `password`.
+
+### URL mode — inline
 
 ```bash
-kubectl create secret generic kora-db --from-literal=DATABASE_URL="postgres://..."
 helm install kora oci://ghcr.io/romderful/kora/charts/kora \
-  --set database.existingSecret=kora-db
+  --set database.url="postgres://kora:secret@pg:5432/kora?sslmode=require"
+```
+
+### URL mode — from existing Secret
+
+```bash
+kubectl create secret generic kora-db \
+  --from-literal=DATABASE_URL="postgres://kora:secret@pg:5432/kora?sslmode=require"
+
+helm install kora oci://ghcr.io/romderful/kora/charts/kora \
+  --set database.existingSecret=kora-db \
+  --set database.secretKeys.url=DATABASE_URL
 ```
 
 ## Production Example
@@ -49,6 +69,7 @@ helm install kora oci://ghcr.io/romderful/kora/charts/kora \
 replicaCount: 3
 
 database:
+  host: postgres.example.com
   existingSecret: kora-db-credentials
 
 ingress:
@@ -112,14 +133,15 @@ resources:
 
 | Parameter | Default | Description |
 |---|---|---|
-| `database.host` | `""` | PostgreSQL host |
-| `database.port` | `5432` | PostgreSQL port |
-| `database.user` | `kora` | PostgreSQL user |
-| `database.password` | `""` | PostgreSQL password |
-| `database.name` | `kora` | PostgreSQL database |
-| `database.url` | `""` | Full DATABASE_URL override |
-| `database.existingSecret` | `""` | Existing secret name |
-| `database.existingSecretKey` | `DATABASE_URL` | Key in existing secret |
+| `database.host` | `""` | PostgreSQL host (plain) |
+| `database.port` | `5432` | PostgreSQL port (plain) |
+| `database.user` | `kora` | PostgreSQL user (plain) |
+| `database.database` | `kora` | PostgreSQL database name (plain) |
+| `database.password` | `""` | Direct password (component mode; goes into the auto-Secret) |
+| `database.url` | `""` | Direct DATABASE_URL (URL mode; goes into the auto-Secret) |
+| `database.existingSecret` | `""` | Existing Secret holding the password or the URL |
+| `database.secretKeys.password` | `password` | Key in existingSecret holding the password |
+| `database.secretKeys.url` | `""` | Key in existingSecret holding the DATABASE_URL — when set, switches to URL mode |
 
 ### Deployment
 

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -25,36 +25,49 @@ Create the name of the service account to use.
 {{- end -}}
 
 {{/*
-Build DATABASE_URL from components.
-Priority: url > host/port/user/password/name.
-*/}}
-{{- define "kora.databaseUrl" -}}
-{{- if .Values.database.url }}
-{{- .Values.database.url }}
-{{- else }}
-{{- printf "postgres://%s:%s@%s:%v/%s" .Values.database.user .Values.database.password .Values.database.host (int .Values.database.port) .Values.database.name }}
-{{- end }}
-{{- end }}
-
-{{/*
-Return the name of the database secret.
+Return the name of the secret containing the database password.
+Uses existingSecret if provided, otherwise returns the auto-created secret name.
 */}}
 {{- define "kora.databaseSecretName" -}}
-{{- if .Values.database.existingSecret }}
-{{- .Values.database.existingSecret }}
-{{- else }}
-{{- include "common.names.fullname" . }}-db
-{{- end }}
-{{- end }}
+{{- if .Values.database.existingSecret -}}
+{{- include "common.tplvalues.render" (dict "value" .Values.database.existingSecret "context" $) -}}
+{{- else -}}
+{{- printf "%s-db" (include "common.names.fullname" .) -}}
+{{- end -}}
+{{- end -}}
 
 {{/*
-Validate values — fail early on misconfiguration.
+Return the database password key — same in the auto-Secret and in existingSecret.
 */}}
-{{- define "kora.validateValues" -}}
-{{- if and (not .Values.database.host) (not .Values.database.url) (not .Values.database.existingSecret) }}
-{{- fail "database: you must set one of database.host, database.url, or database.existingSecret" }}
-{{- end }}
-{{- if and .Values.database.host (not .Values.database.url) (not .Values.database.existingSecret) (not .Values.database.password) }}
-{{- fail "database: database.password is required when using database.host (use database.existingSecret for production)" }}
-{{- end }}
-{{- end }}
+{{- define "kora.databasePasswordKey" -}}
+{{- print .Values.database.secretKeys.password -}}
+{{- end -}}
+
+{{/*
+Returns "true" when the DATABASE_URL is mounted instead of the DB_* components.
+URL mode is active when either database.url is set, or database.existingSecret is
+set together with database.secretKeys.url.
+*/}}
+{{- define "kora.databaseUrlMode" -}}
+{{- if or .Values.database.url (and .Values.database.existingSecret .Values.database.secretKeys.url) -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the database URL key — same in the auto-Secret and in existingSecret.
+Defaults to DATABASE_URL when secretKeys.url is empty (only reached if url mode is active via plain database.url).
+*/}}
+{{- define "kora.databaseUrlKey" -}}
+{{- default "DATABASE_URL" .Values.database.secretKeys.url -}}
+{{- end -}}
+
+{{/*
+Generic helper: fail if neither a direct value nor an existingSecret is provided.
+Usage: include "kora.requireValueOrExistingSecret" (dict "value" .Values.foo.bar "existingSecret" .Values.foo.existingSecret "message" "Either foo.bar or foo.existingSecret must be provided")
+*/}}
+{{- define "kora.requireValueOrExistingSecret" -}}
+{{- if and (not .value) (not .existingSecret) -}}
+{{- fail .message -}}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{- include "kora.validateValues" . }}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
@@ -66,11 +65,27 @@ spec:
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           env:
+            {{- if eq (include "kora.databaseUrlMode" .) "true" }}
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ include "kora.databaseSecretName" . }}
-                  key: {{ .Values.database.existingSecretKey | default "DATABASE_URL" }}
+                  key: {{ include "kora.databaseUrlKey" . | quote }}
+            {{- else }}
+            - name: DB_HOST
+              value: {{ required "database.host is required" .Values.database.host | quote }}
+            - name: DB_PORT
+              value: {{ .Values.database.port | quote }}
+            - name: DB_USER
+              value: {{ .Values.database.user | quote }}
+            - name: DB_NAME
+              value: {{ .Values.database.database | quote }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kora.databaseSecretName" . }}
+                  key: {{ include "kora.databasePasswordKey" . | quote }}
+            {{- end }}
             - name: PORT
               value: {{ .Values.kora.port | quote }}
             - name: DB_POOL_MAX

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -1,14 +1,30 @@
-{{- if not .Values.database.existingSecret }}
+{{- if and .Values.database.existingSecret (or .Values.database.url .Values.database.password) -}}
+{{- fail "database.existingSecret is mutually exclusive with database.url or database.password — pick one source" -}}
+{{- end -}}
+{{- if and .Values.database.url .Values.database.password -}}
+{{- fail "database.url and database.password are mutually exclusive — pick one mode" -}}
+{{- end -}}
+{{- $urlMode := eq (include "kora.databaseUrlMode" .) "true" -}}
+{{- if $urlMode -}}
+{{- include "kora.requireValueOrExistingSecret" (dict "value" .Values.database.url "existingSecret" .Values.database.existingSecret "message" "Either database.url or database.existingSecret (with secretKeys.url) must be provided") -}}
+{{- else -}}
+{{- include "kora.requireValueOrExistingSecret" (dict "value" .Values.database.password "existingSecret" .Values.database.existingSecret "message" "Either database.password or database.existingSecret must be provided") -}}
+{{- end -}}
+{{- if and (not .Values.database.existingSecret) (or .Values.database.password .Values.database.url) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "common.names.fullname" . }}-db
+  name: {{ include "kora.databaseSecretName" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: Opaque
-stringData:
-  DATABASE_URL: {{ include "kora.databaseUrl" . | quote }}
+data:
+  {{- if $urlMode }}
+  {{ include "kora.databaseUrlKey" . }}: {{ .Values.database.url | b64enc | quote }}
+  {{- else }}
+  {{ .Values.database.secretKeys.password }}: {{ .Values.database.password | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -51,24 +51,29 @@ kora:
   extraEnvVarsCM: ""
   extraEnvVarsSecret: ""
 
-## @section Database parameters (external PostgreSQL — REQUIRED)
-## @param database.host PostgreSQL host (REQUIRED unless url or existingSecret is set)
+## @section Database parameters (external PostgreSQL)
+## @param database.host PostgreSQL host
 ## @param database.port PostgreSQL port
 ## @param database.user PostgreSQL user
-## @param database.password PostgreSQL password (ignored if existingSecret is set)
-## @param database.name PostgreSQL database name
-## @param database.url Full DATABASE_URL override (takes priority, for SSL params etc.)
-## @param database.existingSecret Name of existing Secret containing DATABASE_URL
-## @param database.existingSecretKey Key in the existing Secret
+## @param database.database PostgreSQL database name
+## @param database.password Direct value for database password (used if database.existingSecret is not set)
+## @param database.url Direct value for the full DATABASE_URL (used if database.existingSecret is not set); takes priority over components
+## @param database.existingSecret Name of existing secret containing the database password or DATABASE_URL
+## @param database.secretKeys.password Key name in the secret for the database password
+## @param database.secretKeys.url Key name in the secret for the full DATABASE_URL; when set, takes priority over secretKeys.password
 database:
   host: ""
   port: 5432
   user: "kora"
+  database: "kora"
+  ## Direct values (used when existingSecret is not set)
   password: ""
-  name: "kora"
   url: ""
+  ## For using an existing secret
   existingSecret: ""
-  existingSecretKey: "DATABASE_URL"
+  secretKeys:
+    password: "password"
+    url: ""
 
 ## @section Deployment parameters
 ## @param replicaCount Number of Kora replicas

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,8 +11,25 @@ use serde::{Deserialize, Serialize};
 /// Top-level configuration for the Kora server.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct KoraConfig {
-    /// `PostgreSQL` connection string.
+    /// `PostgreSQL` connection string. If empty, composed at startup from
+    /// `DB_HOST` / `DB_PORT` / `DB_USER` / `DB_PASSWORD` / `DB_NAME`.
+    #[serde(default)]
     pub database_url: String,
+    /// `PostgreSQL` host (used when `database_url` is empty).
+    #[serde(default)]
+    pub db_host: String,
+    /// `PostgreSQL` port.
+    #[serde(default = "default_db_port")]
+    pub db_port: u16,
+    /// `PostgreSQL` user.
+    #[serde(default)]
+    pub db_user: String,
+    /// `PostgreSQL` password.
+    #[serde(default)]
+    pub db_password: String,
+    /// `PostgreSQL` database name.
+    #[serde(default)]
+    pub db_name: String,
     /// Host address to bind the server to.
     #[serde(default = "default_host")]
     pub host: String,
@@ -33,6 +50,11 @@ impl Default for KoraConfig {
     fn default() -> Self {
         Self {
             database_url: String::new(),
+            db_host: String::new(),
+            db_port: default_db_port(),
+            db_user: String::new(),
+            db_password: String::new(),
+            db_name: String::new(),
             host: default_host(),
             port: default_port(),
             max_body_size: default_max_body_size(),
@@ -44,24 +66,61 @@ impl Default for KoraConfig {
 impl KoraConfig {
     /// Load configuration from defaults and environment variables.
     ///
-    /// Layer order (last wins): defaults → env vars.
-    /// Uses direct variable names: `DATABASE_URL`, `HOST`, `PORT`,
-    /// `MAX_BODY_SIZE`.
+    /// Recognized env vars: `DATABASE_URL`, `DB_HOST`, `DB_PORT`, `DB_USER`,
+    /// `DB_PASSWORD`, `DB_NAME`, `HOST`, `PORT`, `MAX_BODY_SIZE`, `DB_POOL_MAX`.
+    ///
+    /// When `DATABASE_URL` is empty, it is composed from the `DB_*` components
+    /// (with the user/password percent-encoded).
     ///
     /// # Errors
     ///
-    /// Returns an error if required values are missing or cannot be parsed.
+    /// Returns an error if values cannot be parsed, or if neither `DATABASE_URL`
+    /// nor a complete `DB_*` set (`DB_HOST`, `DB_USER`, `DB_NAME`) is provided.
     pub fn load() -> Result<Self, Box<figment::Error>> {
-        Figment::from(Serialized::defaults(Self::default()))
+        let mut cfg: Self = Figment::from(Serialized::defaults(Self::default()))
             .merge(Env::raw().only(&[
                 "DATABASE_URL",
+                "DB_HOST",
+                "DB_PORT",
+                "DB_USER",
+                "DB_PASSWORD",
+                "DB_NAME",
                 "HOST",
                 "PORT",
                 "MAX_BODY_SIZE",
                 "DB_POOL_MAX",
             ]))
             .extract()
-            .map_err(Box::new)
+            .map_err(Box::new)?;
+
+        if cfg.database_url.is_empty() {
+            let mut missing = Vec::new();
+            if cfg.db_host.is_empty() {
+                missing.push("DB_HOST");
+            }
+            if cfg.db_user.is_empty() {
+                missing.push("DB_USER");
+            }
+            if cfg.db_name.is_empty() {
+                missing.push("DB_NAME");
+            }
+            if !missing.is_empty() {
+                return Err(Box::new(figment::Error::from(format!(
+                    "DATABASE_URL is unset; cannot compose from components — missing: {}",
+                    missing.join(", ")
+                ))));
+            }
+            cfg.database_url = format!(
+                "postgres://{}:{}@{}:{}/{}",
+                urlencoding::encode(&cfg.db_user),
+                urlencoding::encode(&cfg.db_password),
+                cfg.db_host,
+                cfg.db_port,
+                cfg.db_name,
+            );
+        }
+
+        Ok(cfg)
     }
 }
 
@@ -73,6 +132,10 @@ fn default_host() -> String {
 
 fn default_port() -> u16 {
     8080
+}
+
+fn default_db_port() -> u16 {
+    5432
 }
 
 fn default_max_body_size() -> usize {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,6 @@ async fn main() {
 
     let cfg = KoraConfig::load().expect("failed to load configuration");
 
-    assert!(!cfg.database_url.is_empty(), "DATABASE_URL is required");
-
     tracing::info!(host = %cfg.host, port = %cfg.port, "starting Kora");
 
     let metrics_handle = metrics_exporter_prometheus::PrometheusBuilder::new()

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -46,6 +46,7 @@ fn load_uses_database_url_env_when_set() {
 #[test]
 fn load_composes_database_url_from_components() {
     Jail::expect_with(|jail| {
+        jail.set_env("DATABASE_URL", "");
         jail.set_env("DB_HOST", "pg.local");
         jail.set_env("DB_PORT", "6543");
         jail.set_env("DB_USER", "ko@ra");
@@ -64,7 +65,8 @@ fn load_composes_database_url_from_components() {
 
 #[test]
 fn load_errors_when_neither_url_nor_components_provided() {
-    Jail::expect_with(|_jail| {
+    Jail::expect_with(|jail| {
+        jail.set_env("DATABASE_URL", "");
         let err = KoraConfig::load().expect_err("load should fail");
         let msg = err.to_string();
 

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,6 +1,7 @@
 //! Tests for application configuration.
+#![allow(clippy::result_large_err)] // Jail::expect_with's closure must return Result<_, figment::Error>; we can't box.
 
-use figment::{Figment, providers::Serialized};
+use figment::{Figment, Jail, providers::Serialized};
 use kora::config::KoraConfig;
 
 #[test]
@@ -30,13 +31,45 @@ fn config_env_overrides_defaults() {
 }
 
 #[test]
-fn config_database_url_required() {
-    let cfg: KoraConfig = Figment::from(Serialized::defaults(KoraConfig::default()))
-        .extract()
-        .expect("defaults should parse");
+fn load_uses_database_url_env_when_set() {
+    Jail::expect_with(|jail| {
+        jail.set_env("DATABASE_URL", "postgres://from-env/db");
+        jail.set_env("DB_HOST", "should-be-ignored");
 
-    assert!(
-        cfg.database_url.is_empty(),
-        "default database_url should be empty"
-    );
+        let cfg = KoraConfig::load().expect("load should succeed");
+
+        assert_eq!(cfg.database_url, "postgres://from-env/db");
+        Ok(())
+    });
+}
+
+#[test]
+fn load_composes_database_url_from_components() {
+    Jail::expect_with(|jail| {
+        jail.set_env("DB_HOST", "pg.local");
+        jail.set_env("DB_PORT", "6543");
+        jail.set_env("DB_USER", "ko@ra");
+        jail.set_env("DB_PASSWORD", "p@ss/word");
+        jail.set_env("DB_NAME", "kora");
+
+        let cfg = KoraConfig::load().expect("load should succeed");
+
+        assert_eq!(
+            cfg.database_url,
+            "postgres://ko%40ra:p%40ss%2Fword@pg.local:6543/kora"
+        );
+        Ok(())
+    });
+}
+
+#[test]
+fn load_errors_when_neither_url_nor_components_provided() {
+    Jail::expect_with(|_jail| {
+        let err = KoraConfig::load().expect_err("load should fail");
+        let msg = err.to_string();
+
+        assert!(msg.contains("DATABASE_URL"), "{msg}");
+        assert!(msg.contains("DB_HOST"), "{msg}");
+        Ok(())
+    });
 }


### PR DESCRIPTION
Closes #30

## Summary

- split `database` config into Component (host/port/user/database + password) and URL (full DATABASE_URL) modes; both modes accept `existingSecret`
- replace `existingSecretKey` with `secretKeys.{password,url}`; rename `database.name` → `database.database`
- emit Secret payload as `data` (b64enc) instead of `stringData`
- fail at template time when `existingSecret` combines with `url` or `password`, or when `url` and `password` are both set
- compose `DATABASE_URL` at startup from `DB_*` env vars with percent-encoded user/password when `DATABASE_URL` is unset; drop the redundant startup assert
- expand CI with rendered-template assertions for the four valid scenarios and three mutex failures (asserts both exit code and message contains `mutually exclusive`)
- isolate config tests with `figment::Jail`, explicitly overriding `DATABASE_URL` to empty in tests that exercise the unset case (defends against parent-process env leakage)

## Test plan

- [x] `cargo test --test config` — 5 tests pass with and without inherited `DATABASE_URL`
- [x] `helm lint chart/ --set database.host=lint --set database.password=lint` — passes
- [x] `helm template kora chart/ --set database.host=h --set database.password=p` — auto-Secret + DB_* env block
- [x] `helm template kora chart/ --set database.host=h --set database.existingSecret=s --set database.secretKeys.password=db-password` — no auto-Secret, DB_PASSWORD references `s/db-password`
- [x] `helm template kora chart/ --set database.url=URL` — auto-Secret + DATABASE_URL env via secretKeyRef
- [x] `helm template kora chart/ --set database.existingSecret=s --set database.secretKeys.url=DATABASE_URL` — no auto-Secret, DATABASE_URL references `s/DATABASE_URL`
- [x] mutex `database.url + database.existingSecret` → fails with "mutually exclusive"
- [x] mutex `database.password + database.existingSecret` → fails with "mutually exclusive"
- [x] mutex `database.url + database.password` → fails with "mutually exclusive"
