### PR TITLE
QA: Kotatsu integration e2e catalogue + first execution results (3 issues filed)

### DIFF
--- a/tests/e2e/first-batch.md
+++ b/tests/e2e/first-batch.md
@@ -1,4 +1,11 @@
-# Kora — First batch: manual P1 runbook
+# Kora — First batch: manual P1 runbook (Kora API in isolation)
+
+> **📌 Scope note (read first):** this runbook tests **Kora on its own** (its REST API,
+> against a standalone Kora + local Postgres via `just dev`). It is now a **fallback /
+> reference** for exercising Kora in isolation. The primary e2e deliverable is
+> [`kotatsu-integration.md`](./kotatsu-integration.md) — the live **Kora ↔ Kotatsu**
+> chain observed from the UI. ⚠️ Running `just dev` while the data-plane stack is up
+> will conflict on port 5432; only use this runbook when the data-plane is **not** running.
 
 > **Goal:** a ready-to-run checklist of the most critical (P1) end-to-end cases from
 > [`test-cases.md`](./test-cases.md). Each step is a copy-paste `curl` command plus the

--- a/tests/e2e/kotatsu-integration.md
+++ b/tests/e2e/kotatsu-integration.md
@@ -194,7 +194,7 @@ Priority: `P1` core product promise · `P2` important · `P3` edge.
   of schema evolution and the most valuable assertion of the scenario.
 
 ### KKI-EVO-003 — Both versions visible in the Schemas tab — `P2`
-- **Steps:** `curl -sk "$K/schemas/<subject>" | jq '{version, id, type}'` and the
+- **Steps:** `curl -sk "$K/schemas/<subject>" | jq '{versions, latest: (.latest | {id, version, schemaType})}'` and the
   `/schemas/{subject}` UI page.
 - **Expected:** the subject reports the latest version (≥2) while older events still map
   to earlier ids; type stays `AVRO`.
@@ -206,10 +206,17 @@ Priority: `P1` core product promise · `P2` important · `P3` edge.
 > **Proves:** a translator outage degrades gracefully — Kotatsu stays up, shows hex + a
 > clear error, and recovers when Kora returns. A Kora failure must never crash the browser.
 
-> **Precondition / known blocker:** these need Kora scaled down in the `kafka` namespace,
-> e.g. `kubectl -n kafka scale deploy/kora --replicas=0` (restore with `--replicas=1`).
-> **`kubectl` is not yet on PATH locally** — it is wrapped by the data-plane (`tasks`
-> `KUBECTL` constant). **TODO: confirm the exact invocation before executing this block.**
+> **Precondition (blocker resolved 2026-06-11):** these need Kora scaled down in the
+> `kafka` namespace. No local `kubectl` exists; go **through the Kind node container**,
+> which ships its own kubectl + admin kubeconfig:
+>
+> ```bash
+> # scale down / up
+> docker exec -i popsink-data-plane-dev-control-plane \
+>   kubectl --kubeconfig /etc/kubernetes/admin.conf -n kafka scale deploy/kora --replicas=0
+> docker exec -i popsink-data-plane-dev-control-plane \
+>   kubectl --kubeconfig /etc/kubernetes/admin.conf -n kafka scale deploy/kora --replicas=1
+> ```
 
 ### KKI-RES-001 — With Kora down, events show hex + error, UI survives — `P1`
 - **Steps:** scale Kora to 0 → in Kotatsu **Search** `$TOPIC` (use a fresh fetch; cached
@@ -266,22 +273,22 @@ Priority: `P1` core product promise · `P2` important · `P3` edge.
 
 | Case | Pri | Proves | Pass? |
 |---|:--:|---|:--:|
-| KKI-DEC-001 | P1 | Avro event → readable JSON | ☐ |
-| KKI-DEC-002 | P1 | Event id resolves to a real subject | ☐ |
-| KKI-DEC-003 | P2 | Whole partition decodes (0 hex) | ☐ |
-| KKI-DEC-004 | P2 | Non-Avro key not force-decoded | ☐ |
-| KKI-DEC-005 | P3 | Logical types stay readable | ☐ |
+| KKI-DEC-001 | P1 | Avro event → readable JSON | ✅ 2026-06-11 |
+| KKI-DEC-002 | P1 | Event id resolves to a real subject | ✅ 2026-06-11 |
+| KKI-DEC-003 | P2 | Whole partition decodes (0 hex) | ✅ 2026-06-11 |
+| KKI-DEC-004 | P2 | Non-Avro key not force-decoded | ✅ 2026-06-11 |
+| KKI-DEC-005 | P3 | Logical types stay readable | ✅ 2026-06-11 |
 | KKI-EVO-001 | P1 | New events use the new version | ☐ |
 | KKI-EVO-002 | P1 | Old events still readable (no regression) | ☐ |
 | KKI-EVO-003 | P2 | Both versions visible | ☐ |
-| KKI-RES-001 | P1 | Kora down → hex + error, UI alive | ☐ |
-| KKI-RES-002 | P1 | Schemas tab degrades cleanly | ☐ |
-| KKI-RES-003 | P1 | Decode resumes after recovery | ☐ |
-| KKI-RES-004 | P3 | Unknown id behaves like outage | ☐ |
-| KKI-SCH-001 | P1 | Schemas list mirrors Kora | ☐ |
-| KKI-SCH-002 | P1 | Subject detail matches Kora | ☐ |
-| KKI-SCH-003 | P2 | Registry URL is the cluster Kora | ☐ |
-| KKI-SCH-004 | P3 | Unknown subject errors cleanly | ☐ |
+| KKI-RES-001 | P1 | Kora down → hex + error, UI alive | ⚠️ FAIL partial 2026-06-11 (ANO-1, ANO-2) |
+| KKI-RES-002 | P1 | Schemas tab degrades cleanly | ✅ 2026-06-11 |
+| KKI-RES-003 | P1 | Decode resumes after recovery | ✅ 2026-06-11 |
+| KKI-RES-004 | P3 | Unknown id behaves like outage | ⏭ skipped (needs subject hard-delete; reference data irreplaceable until a source pipeline is re-provisioned) |
+| KKI-SCH-001 | P1 | Schemas list mirrors Kora | ✅ 2026-06-11 |
+| KKI-SCH-002 | P1 | Subject detail matches Kora | ✅ 2026-06-11 |
+| KKI-SCH-003 | P2 | Registry URL is the cluster Kora | ✅ 2026-06-11 |
+| KKI-SCH-004 | P3 | Unknown subject errors cleanly | ✅ 2026-06-11 |
 
 ---
 
@@ -291,8 +298,34 @@ Priority: `P1` core product promise · `P2` important · `P3` edge.
   `response.status()` and the parsed body; each UI step maps to `page.goto` +
   `getByRole('button',{name:/search/i}).click()` + assertions on the rendered rows. The
   `value.kind` checks become the primary `expect(...)`.
-- **Blocker — scenario 3:** needs the kubectl invocation used by the data-plane to scale
-  the `kora` deployment. Resolve before running `RES` cases.
+- **Blocker — scenario 3: resolved** (2026-06-11): use the Kind node's embedded kubectl
+  via `docker exec` (see scenario 3 precondition).
+- **Blocker — scenario 2 (EVO):** the source Postgres that produced the reference events
+  (db `popsink_source`, connector `e2e-source-pg`) **no longer exists** — it is not on the
+  cluster's `postgresql-0` (only `data_plane`, `control_plane`, `kora`… databases) and no
+  other container is present. No CDC pipeline is currently running (no `workers` pods);
+  the reference events are S3 leftovers from a previous session. EVO needs either a
+  re-provisioned source + pipeline (full chain) or synthetic v2 Avro events produced
+  straight to Tansu (strict Kora↔Kotatsu scope).
+- **Findings — KKI-RES-001 (2026-06-11), verdict FAIL partial.** Structural resilience
+  holds (HTTP 200, hex fallback, keys/offsets intact, no crash, clean recovery), but:
+  - **ANO-1 — hex fallback carries no diagnostic** (filed as [data-plane#2650](https://github.com/Popsink/data-plane/issues/2650)). With Kora down, affected events
+    come back as `{kind:"hex", data}` — **no `schemaId`, no `error`**. Root cause: the
+    deployed image is `ghcr.io/popsink/kotatsu:0.1.0`, whose `decode_field` silently
+    falls through to `raw_field` on registry failure. The diagnostic path
+    (`{kind:"hex", schemaId, error:"schema id N: …"}`) exists since v0.2.0
+    (commit `8aedf61`). **Recommendation:** bump the kotatsu image in the data-plane
+    deployment to ≥0.2.0, then re-run this case.
+  - **ANO-2 — registry client has no timeout** (filed as [kotatsu#55](https://github.com/Popsink/kotatsu/issues/55)). `SchemaRegistry` uses
+    `reqwest::Client::new()` (no timeout, no negative caching) — `schema.rs:77`, present
+    in 0.1.0 **and** current HEAD. With Kora's Service blackholed, message fetches
+    intermittently hang **~25-30 s** (UI stuck on "Loading…", no feedback); other runs
+    fail instantly (502 in 0.17 s on `/api/schemas`). **Recommendation:** set a short
+    client timeout (1-2 s) and consider briefly caching fetch failures.
+- **Minor observation (KKI-SCH-004 + KKI-RES-002, 2026-06-11):** error messages leak
+  internal registry routes/URLs (404: `subject '/subjects/<name>/versions' not found`;
+  502: full in-cluster Kora URL). Cosmetic; filed as
+  [kotatsu#56](https://github.com/Popsink/kotatsu/issues/56).
 - **Caching caveat (scenario 3):** Kotatsu caches resolved schemas (ids are immutable),
   so an already-fetched id may still decode after Kora goes down. Use a not-yet-fetched
   topic/id, or a fresh session, to observe the outage path honestly.

--- a/tests/e2e/kotatsu-integration.md
+++ b/tests/e2e/kotatsu-integration.md
@@ -271,6 +271,12 @@ Priority: `P1` core product promise · `P2` important · `P3` edge.
 
 ## 9. Execution checklist
 
+> **2026-06-15 environment note:** reference Avro data on both `…public.items` topics has
+> been purged (records gone, watermark still reads 25/30 — see ANO-3 in §10). The 2026-06-11
+> ✅ results below were valid that day but are **not currently reproducible**: DEC, RES-001
+> and EVO need Avro data regenerated first. Kotatsu is now `0.2.1`, so RES-001 (ANO-1) is
+> ready to re-test the moment data returns.
+
 | Case | Pri | Proves | Pass? |
 |---|:--:|---|:--:|
 | KKI-DEC-001 | P1 | Avro event → readable JSON | ✅ 2026-06-11 |
@@ -281,9 +287,9 @@ Priority: `P1` core product promise · `P2` important · `P3` edge.
 | KKI-EVO-001 | P1 | New events use the new version | ☐ |
 | KKI-EVO-002 | P1 | Old events still readable (no regression) | ☐ |
 | KKI-EVO-003 | P2 | Both versions visible | ☐ |
-| KKI-RES-001 | P1 | Kora down → hex + error, UI alive | ⚠️ FAIL partial 2026-06-11 (ANO-1, ANO-2) |
-| KKI-RES-002 | P1 | Schemas tab degrades cleanly | ✅ 2026-06-11 |
-| KKI-RES-003 | P1 | Decode resumes after recovery | ✅ 2026-06-11 |
+| KKI-RES-001 | P1 | Kora down → hex + error, UI alive | ✅ 2026-06-15 (ANO-1 & ANO-2 fixed in 0.2.1; see ui-deep-dive) |
+| KKI-RES-002 | P1 | Schemas tab degrades cleanly | ✅ 2026-06-11 · re-confirmed 2026-06-15 (no URL leak) |
+| KKI-RES-003 | P1 | Decode resumes after recovery | ✅ 2026-06-11 · re-confirmed 2026-06-15 |
 | KKI-RES-004 | P3 | Unknown id behaves like outage | ⏭ skipped (needs subject hard-delete; reference data irreplaceable until a source pipeline is re-provisioned) |
 | KKI-SCH-001 | P1 | Schemas list mirrors Kora | ✅ 2026-06-11 |
 | KKI-SCH-002 | P1 | Subject detail matches Kora | ✅ 2026-06-11 |
@@ -294,6 +300,28 @@ Priority: `P1` core product promise · `P2` important · `P3` edge.
 
 ## 10. Notes & open items
 
+- **Environment update (2026-06-15):** the deployed Kotatsu image is now
+  `ghcr.io/popsink/kotatsu:0.2.1` (was `0.1.0` on 2026-06-11); Kora is `v0.3.3`. The 0.2.x
+  bump is the prerequisite ANO-1 was waiting for — **KKI-RES-001 is now re-runnable**, but
+  only once decodable Avro data exists again (see the data-loss finding below).
+- **Findings — reference Avro data lost to retention (2026-06-15), verdict FAIL / blocker
+  + new defect ANO-3.** Attempting to re-run scenario 1 (DEC) found **zero readable events**
+  on both `…public.items` topics: `GET …/messages` returns `count:0, scanned:0,
+  exhausted:true` while `watermark.high` still reads **25** / **30**. Cross-checked on the
+  RustFS S3 backend (bucket `tansu`, endpoint `rustfs-svc.rustfs.svc.cluster.local:9000`):
+  both `…public.items` partitions hold **only `watermark.json` and no `records/` directory
+  (0 batches)**, whereas every compacted `connect.*` topic still has its `records/*.batch`
+  files. Root cause (hypothesis): the CDC `public.items` topics use a time-based *delete*
+  retention policy and their record batches have aged out, while the watermark metadata
+  survives the purge. With no source pipeline to regenerate them, the reference events are
+  gone — DEC, RES-001 (the ANO-1 re-test), and EVO are all blocked until data is restored.
+  - **ANO-3 — phantom message count: watermark survives record purge** (to file). After the
+    record batches are deleted, Kotatsu still advertises `high:25` (topic list shows "25
+    messages") yet every fetch returns `count:0` **with no error and no empty-state hint** —
+    a user sees a non-zero counter but can never open a single message. Invisible/inconsistent
+    state, exactly the operational-gap class we hunt. **Recommendation:** reconcile the
+    displayed count with the readable `low`/available range, or surface an explicit
+    "records purged / unavailable" state instead of a silent empty result.
 - **Playwright transposition:** each curl maps to a `request.get(...)` asserting on
   `response.status()` and the parsed body; each UI step maps to `page.goto` +
   `getByRole('button',{name:/search/i}).click()` + assertions on the rendered rows. The
@@ -306,7 +334,10 @@ Priority: `P1` core product promise · `P2` important · `P3` edge.
   other container is present. No CDC pipeline is currently running (no `workers` pods);
   the reference events are S3 leftovers from a previous session. EVO needs either a
   re-provisioned source + pipeline (full chain) or synthetic v2 Avro events produced
-  straight to Tansu (strict Kora↔Kotatsu scope).
+  straight to Tansu (strict Kora↔Kotatsu scope). **Update 2026-06-15:** those leftover
+  events have since been purged (see the data-loss finding below), so this same
+  data-regeneration step now also gates DEC re-runs and the RES-001 re-test — it is the
+  single unblock for the whole remaining suite.
 - **Findings — KKI-RES-001 (2026-06-11), verdict FAIL partial.** Structural resilience
   holds (HTTP 200, hex fallback, keys/offsets intact, no crash, clean recovery), but:
   - **ANO-1 — hex fallback carries no diagnostic** (filed as [data-plane#2650](https://github.com/Popsink/data-plane/issues/2650)). With Kora down, affected events

--- a/tests/e2e/kotatsu-integration.md
+++ b/tests/e2e/kotatsu-integration.md
@@ -1,0 +1,302 @@
+# Kora ↔ Kotatsu — End-to-End Integration Test Catalogue
+
+> **Status:** Living document — the primary e2e deliverable. Functional spec of the
+> *integration* behaviour, executable by hand (curl + browser) and transposable
+> 1-for-1 into Playwright API/UI calls later. **No test code required.**
+>
+> **Scope:** what happens when **Kotatsu** (the read-only S3 event browser) uses
+> **Kora** (the schema registry) to decode Avro events end-to-end. This is the layer
+> the developer's unit tests do *not* cover: the real chain, observed from the outside.
+>
+> **Why this exists (and why it is not `test-cases.md`):** re-testing Kora's REST API
+> in isolation duplicates the developer's unit/integration tests. The unique QA value
+> is proving Kora does its job *inside the live chain* — a user opens Kotatsu and an
+> event is either **readable JSON** (Kora delivered the right schema) or **hex + an
+> error** (Kora failed). That is observable, black-box, and ours to own.
+> `test-cases.md` and `first-batch.md` remain as the **Kora-in-isolation API reference**.
+
+---
+
+## 1. The chain under test
+
+```
+Postgres (source)  ──CDC──▶  Tansu (Kafka-compatible broker, writes to S3)
+                                       │
+                                       ▼  raw Confluent-Avro bytes in S3
+                              Kotatsu (reads S3 directly, on demand)
+                                       │  reads schema id from the event…
+                                       ▼  …GET /schemas/ids/{id}
+                                     Kora  ──▶  returns the Avro schema ("the mould")
+                                       │
+                                       ▼
+                              Kotatsu decodes ──▶ readable JSON in the UI
+```
+
+A Confluent-framed Avro event on the wire is: `[0x00][4-byte big-endian schema id][Avro body]`.
+Kotatsu reads the id, asks Kora for the matching schema, and decodes the body.
+**If Kora is unreachable or returns the wrong/absent schema, Kotatsu cannot decode** —
+it falls back to hex and surfaces an error. That fork is the heart of every case below.
+
+---
+
+## 2. Environment & access
+
+| Thing | Value |
+|---|---|
+| Kotatsu UI | `https://kotatsu.ppsk.localhost/` (self-signed TLS → `curl -k`) |
+| Kotatsu API base | `https://kotatsu.ppsk.localhost/api` |
+| Kora (the one actually used) | `http://kora.kafka.svc.cluster.local:8080` — **in the Kind cluster**, brought up by the data-plane `inv up`. |
+| Cluster name in Kotatsu | `tansu` |
+
+> ⚠️ **Do _not_ run `just dev` in the kora repo for this suite.** That spins up a
+> *separate, local* Kora + Postgres that Kotatsu never talks to, and it fights the
+> data-plane for port 5432. The Kora under test is the cluster one, reached only
+> through Kotatsu.
+
+**Kotatsu API surface used here:**
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /api/health` | liveness |
+| `GET /api/clusters` | list clusters |
+| `GET /api/clusters/{c}/topics` | list topics + message counts |
+| `GET /api/clusters/{c}/topics/{t}` | partition watermarks (no payloads) |
+| `GET /api/clusters/{c}/topics/{t}/messages?partition=&offset=&limit=` | **decoded events** |
+| `GET /api/schemas` | registry URL + subject list |
+| `GET /api/schemas/{subject}` | one subject's schema, version, id |
+
+**Matching UI routes** (for the browser side of each case): `/` (overview),
+`/topics`, `/topics/{name}`, `/schemas`, `/schemas/{subject}`, `/groups`.
+
+> **UI behaviour to remember:** the topic page loads events **on demand** — you must
+> pick a partition / `From` (earliest|latest) and click **Search**. No polling.
+
+**Copy-paste setup for the curl steps:**
+
+```bash
+export K=https://kotatsu.ppsk.localhost/api
+export CL=tansu
+# A healthy data topic with Avro events (table `items`, 25 events, schema id 1):
+export TOPIC=dfa38c487e7.eecc277a729.c93b93b71d2.public.items
+# jq is optional but makes assertions readable.
+```
+
+---
+
+## 3. The central assertion — `value.kind`
+
+Every decoded event's `value` (and `key`) carries a `kind` field. **This is the single
+most important signal in the whole suite.** Values are taken directly from Kotatsu's
+decoder (`backend/src/schema.rs`):
+
+| `value.kind` | Meaning | Verdict on Kora |
+|---|---|---|
+| `avro` + `data` is JSON, **no `error`** | schema fetched, body decoded | ✅ **Kora OK** |
+| `hex` + `schemaId` + `error` | schema could **not** be fetched (Kora down / id absent) | ❌ **Kora failed** |
+| `avro` + `data` is hex + `error:"avro decode failed…"` | schema fetched but body didn't match it | ⚠️ schema/data mismatch |
+| `raw` | bytes had no `0x00` Confluent frame | n/a (not Avro-framed) |
+| `json` / `utf8` | non-Avro field (e.g. the Debezium JSON key) | n/a |
+
+A passing nominal event therefore satisfies: `value.kind == "avro"` **and** `value.error`
+is absent **and** `value.data` is a JSON object with the expected fields.
+
+---
+
+## 4. Reference test data (as observed in the live cluster)
+
+- **Subjects in Kora:** `…c68a146751d.public.items-value`, `…c93b93b71d2.public.items-value`,
+  `…cc0b4723181.public.items-value` (Confluent `<topic>-value` naming).
+- **Topics with Avro data:** `…c93b93b71d2.public.items` (25 events), `…cc0b4723181.public.items` (30 events).
+- **`items` record fields:** `id` (long), `item` (string), `qty` (int), `category`
+  (nullable string), `in_stock` (boolean), `updated_at` (nullable ZonedTimestamp).
+  Wrapped in a Debezium `Envelope` (`before`, `after`, `source`, `op`, `ts_ms`, …).
+- **Sample decoded values:** `{id:3,item:"ruler",qty:17,category:"stationery",in_stock:true}`,
+  `{id:4,item:"scissors",…}`, `{id:5,item:"glue",…}`.
+
+---
+
+## How to read a case
+
+`KKI-<DOMAIN>-<NNN>` — stable id, never reused. Domains: `DEC` decode nominal ·
+`EVO` schema evolution · `RES` resilience / Kora outage · `SCH` Schemas tab.
+Priority: `P1` core product promise · `P2` important · `P3` edge.
+
+---
+
+## 5. Scenario 1 — Nominal decode (`DEC`)
+
+> **Proves:** in the live chain, Kotatsu asks Kora for the right schema and renders the
+> event as readable JSON. This is *the* reason the integration matters.
+
+### KKI-DEC-001 — An Avro event is shown as readable JSON — `P1`
+- **Preconditions:** stack up; `$TOPIC` has ≥1 event; Kora reachable.
+- **Steps (API):**
+  ```bash
+  curl -sk "$K/clusters/$CL/topics/$TOPIC/messages?partition=0&offset=0&limit=5" \
+    | jq '.records[0].value'
+  ```
+- **Steps (UI):** open `/topics/$TOPIC` → `From=earliest` → **Search** → expand the first event.
+- **Expected:** `value.kind == "avro"`, **no** `value.error`, and `value.data` is a JSON
+  object containing `after.item` (e.g. `"ruler"`), `after.qty`, `after.id`. In the UI the
+  row reads as plain JSON, **not** hex.
+
+### KKI-DEC-002 — Event's schema id resolves to a real Kora subject — `P1`
+- **Preconditions:** KKI-DEC-001 passed.
+- **Steps:** note `value.schemaId` from KKI-DEC-001, then
+  ```bash
+  curl -sk "$K/schemas" | jq '.subjects'
+  ```
+- **Expected:** the topic's `…items-value` subject is present in Kora, and the
+  `schemaId` Kotatsu used is a valid id for it. (Closes the loop: the id in the event
+  is the id Kora knows.)
+
+### KKI-DEC-003 — Every event on a healthy topic decodes — `P2`
+- **Steps:**
+  ```bash
+  curl -sk "$K/clusters/$CL/topics/$TOPIC/messages?partition=0&offset=0&limit=100" \
+    | jq '[.records[].value.kind] | group_by(.) | map({(.[0]): length}) | add'
+  ```
+- **Expected:** `{"avro": 25}` — i.e. **zero** `hex` and zero `value.error` across the
+  whole partition. A single `hex` here is a finding.
+
+### KKI-DEC-004 — Non-Avro key is rendered without error — `P2`
+- **Steps:** inspect `.records[0].key` from the same fetch.
+- **Expected:** the Debezium key is shown as `kind:"utf8"`/`"json"` (it is JSON, not
+  Confluent-Avro) — Kotatsu must **not** force-Avro it or hex it. Confirms field-level
+  format detection is independent per field.
+
+### KKI-DEC-005 — Logical/typed fields stay human-readable — `P3`
+- **Steps:** inspect `after.in_stock`, `after.updated_at`, `after.qty` in a decoded event.
+- **Expected:** `in_stock` is a real boolean, `qty` an integer, `updated_at` a readable
+  timestamp string (not hex bytes) — i.e. Kora's logical-type schema is honoured by the
+  decoder.
+
+---
+
+## 6. Scenario 2 — Schema evolution (`EVO`)
+
+> **Proves:** when the source schema changes, Kora serves multiple versions and Kotatsu
+> resolves **each event by its own schema id** — so new events become readable **without
+> breaking the old ones**.
+
+### KKI-EVO-001 — New events after an evolution decode against the new version — `P1`
+- **Preconditions:** ability to evolve the source table (e.g. `ALTER TABLE items ADD
+  COLUMN sku text`) and let CDC produce new events; **backward-compatible** change.
+- **Steps:** evolve + insert a row → in Kotatsu, **Search** `From=latest` on `$TOPIC`.
+- **Expected:** the newest event has `value.kind == "avro"`, no `error`, and `value.data`
+  includes the new field (`after.sku`). Its `schemaId` differs from the v1 events'.
+
+### KKI-EVO-002 — Pre-evolution events remain readable — `P1`
+- **Preconditions:** KKI-EVO-001 done (registry now holds ≥2 versions of the subject).
+- **Steps:** **Search** `From=earliest` and inspect the *oldest* events.
+- **Expected:** old events still `kind:"avro"`, no `error`, decoded with their **original**
+  `schemaId` (the new field simply absent). **No regression** — this is the core promise
+  of schema evolution and the most valuable assertion of the scenario.
+
+### KKI-EVO-003 — Both versions visible in the Schemas tab — `P2`
+- **Steps:** `curl -sk "$K/schemas/<subject>" | jq '{version, id, type}'` and the
+  `/schemas/{subject}` UI page.
+- **Expected:** the subject reports the latest version (≥2) while older events still map
+  to earlier ids; type stays `AVRO`.
+
+---
+
+## 7. Scenario 3 — Resilience when Kora is down (`RES`)
+
+> **Proves:** a translator outage degrades gracefully — Kotatsu stays up, shows hex + a
+> clear error, and recovers when Kora returns. A Kora failure must never crash the browser.
+
+> **Precondition / known blocker:** these need Kora scaled down in the `kafka` namespace,
+> e.g. `kubectl -n kafka scale deploy/kora --replicas=0` (restore with `--replicas=1`).
+> **`kubectl` is not yet on PATH locally** — it is wrapped by the data-plane (`tasks`
+> `KUBECTL` constant). **TODO: confirm the exact invocation before executing this block.**
+
+### KKI-RES-001 — With Kora down, events show hex + error, UI survives — `P1`
+- **Steps:** scale Kora to 0 → in Kotatsu **Search** `$TOPIC` (use a fresh fetch; cached
+  schemas may still decode, so prefer a topic/id not yet fetched this session).
+- **Expected:** affected events become `value.kind == "hex"` with a `schemaId` and an
+  `error`; the page still returns HTTP 200; offsets, headers, key and topic list still
+  render. **No crash, no blank page.**
+
+### KKI-RES-002 — Schemas tab degrades cleanly when Kora is down — `P1`
+- **Steps:** with Kora at 0 replicas, open `/schemas` (and `GET /api/schemas`).
+- **Expected:** a clear error/empty state surfaced to the user — **not** a stack trace,
+  hang, or 500 that takes the page down.
+
+### KKI-RES-003 — Recovery: decode resumes after Kora returns — `P1`
+- **Steps:** scale Kora back to 1 → re-**Search** the same topic.
+- **Expected:** events decode again (`kind:"avro"`, no `error`). Confirms the failure was
+  transient and Kotatsu re-fetches schemas rather than caching the failure.
+
+### KKI-RES-004 — Unknown/deleted schema id behaves like an outage — `P3`
+- **Steps:** target an event whose schema id is absent from Kora (e.g. after a hard-delete
+  of that subject in a throwaway environment), with Kora **up**.
+- **Expected:** `kind:"hex"`, `schemaId` present, `error` present — same graceful path as
+  a full outage; the rest of the event (headers, key, offset) still renders.
+
+---
+
+## 8. Scenario 4 — Schemas tab reflects Kora (`SCH`)
+
+> **Proves:** Kotatsu's Schemas view is a faithful, read-only mirror of Kora's content.
+
+### KKI-SCH-001 — Schemas tab lists every Kora subject — `P1`
+- **Steps:** `curl -sk "$K/schemas" | jq '.subjects'` vs the `/schemas` UI list.
+- **Expected:** the three `…public.items-value` subjects appear in both; counts match;
+  no subject missing or invented.
+
+### KKI-SCH-002 — Subject detail matches Kora — `P1`
+- **Steps:** open `/schemas/<subject>` (the UI page you saw: type, latest version, schema
+  id, full Avro schema).
+- **Expected:** `type = AVRO`, a version (e.g. `1`), a `schema id` (e.g. `1`), and the full
+  `Envelope` schema with the `items` fields — all consistent with what Kora returns.
+
+### KKI-SCH-003 — Displayed registry URL matches the configured Kora — `P2`
+- **Steps:** `curl -sk "$K/schemas" | jq '.registry'`.
+- **Expected:** `http://kora.kafka.svc.cluster.local:8080` — proves Kotatsu is wired to the
+  cluster Kora (not a stray local one).
+
+### KKI-SCH-004 — Unknown subject errors cleanly — `P3`
+- **Steps:** `curl -sk -o /dev/null -w "%{http_code}\n" "$K/schemas/does-not-exist-xyz"`.
+- **Expected:** a clean 404/error response and a graceful UI state — no crash.
+
+---
+
+## 9. Execution checklist
+
+| Case | Pri | Proves | Pass? |
+|---|:--:|---|:--:|
+| KKI-DEC-001 | P1 | Avro event → readable JSON | ☐ |
+| KKI-DEC-002 | P1 | Event id resolves to a real subject | ☐ |
+| KKI-DEC-003 | P2 | Whole partition decodes (0 hex) | ☐ |
+| KKI-DEC-004 | P2 | Non-Avro key not force-decoded | ☐ |
+| KKI-DEC-005 | P3 | Logical types stay readable | ☐ |
+| KKI-EVO-001 | P1 | New events use the new version | ☐ |
+| KKI-EVO-002 | P1 | Old events still readable (no regression) | ☐ |
+| KKI-EVO-003 | P2 | Both versions visible | ☐ |
+| KKI-RES-001 | P1 | Kora down → hex + error, UI alive | ☐ |
+| KKI-RES-002 | P1 | Schemas tab degrades cleanly | ☐ |
+| KKI-RES-003 | P1 | Decode resumes after recovery | ☐ |
+| KKI-RES-004 | P3 | Unknown id behaves like outage | ☐ |
+| KKI-SCH-001 | P1 | Schemas list mirrors Kora | ☐ |
+| KKI-SCH-002 | P1 | Subject detail matches Kora | ☐ |
+| KKI-SCH-003 | P2 | Registry URL is the cluster Kora | ☐ |
+| KKI-SCH-004 | P3 | Unknown subject errors cleanly | ☐ |
+
+---
+
+## 10. Notes & open items
+
+- **Playwright transposition:** each curl maps to a `request.get(...)` asserting on
+  `response.status()` and the parsed body; each UI step maps to `page.goto` +
+  `getByRole('button',{name:/search/i}).click()` + assertions on the rendered rows. The
+  `value.kind` checks become the primary `expect(...)`.
+- **Blocker — scenario 3:** needs the kubectl invocation used by the data-plane to scale
+  the `kora` deployment. Resolve before running `RES` cases.
+- **Caching caveat (scenario 3):** Kotatsu caches resolved schemas (ids are immutable),
+  so an already-fetched id may still decode after Kora goes down. Use a not-yet-fetched
+  topic/id, or a fresh session, to observe the outage path honestly.
+- **P2/P3** cases can be promoted into a focused execution batch once the P1 path is green,
+  the same way `first-batch.md` was carved out of `test-cases.md`.
+</content>
+</invoke>

--- a/tests/e2e/kotatsu-ui-deep-dive.md
+++ b/tests/e2e/kotatsu-ui-deep-dive.md
@@ -1,0 +1,189 @@
+# Kotatsu UI — Deep-Dive E2E / White-Box Test Session
+
+> **Date:** 2026-06-15 · **Target:** deployed Kotatsu `0.2.1` (image
+> `ghcr.io/popsink/kotatsu:0.2.1`), Kora `v0.3.3`, live Kind cluster.
+> **Method:** black-box e2e through the real UI (Playwright, headed) + HTTP API probes,
+> **grounded in the source at the exact deployed commit** (`~/Documents/kotatsu` @ `b3d558e`,
+> tag boundary `v0.2.1`) — i.e. white-box-informed e2e. No app code was modified.
+> **Data under test:** topic `…c197b708407.pokemon` (1350 Avro events, schema id 15),
+> freshly produced by a DLT source → Postgres subscription. Companion to
+> [`kotatsu-integration.md`](./kotatsu-integration.md).
+
+## Scope & approach
+
+The session targets the layer unit tests don't cover: the live UI behaviour of the
+Kora↔Kotatsu chain, plus input/error/edge handling. Test ideas were derived from a
+white-box read of the frontend (`frontend/pages/topics/[name].vue`, list pages, decoding
+render helpers) and backend (`backend/src/api.rs`, `schema.rs`, `storage/reader.rs`), so each
+case exercises a real branch rather than a generic checklist item.
+
+## Confirmed in 0.2.1 (regression checks vs the 2026-06-11 findings)
+
+| Prior finding | Status in 0.2.1 | Evidence |
+|---|---|---|
+| ANO-1 — hex fallback had no `schemaId`/`error` | **Fixed — confirmed live** | `schema.rs:228,245` emit `{kind:"hex", schemaId, error}`; outage test returned `{kind:"hex", schemaId:13, error:"schema id 13: schema registry is unreachable"}` (API + UI). |
+| ANO-2 — registry client had no timeout | **Fixed — confirmed live** | `schema.rs:77-91` sets `connect_timeout=2s`, `timeout=5s`; outage responses came back in ~0.01 s with no multi-second hang. |
+| kotatsu#56 — error messages leak internal Kora URL | **Partially fixed** | Schema/registry errors now sanitized (`/schemas` down → `{"error":"schema registry is unreachable"}`, no URL), **but storage errors still leak** — see KUI-BUG-1. |
+
+## Executed cases
+
+Legend: ✅ pass · 🐛 defect · 📝 observation · ⏸ blocked.
+
+| ID | Area | Action → Expected | Result |
+|---|---|---|---|
+| API-1 | validation | `offset=foobar` → 400 + clear msg | ✅ `400 {"error":"invalid offset: foobar"}` |
+| API-2 | validation | `value_contains=[`&`regex=true` → 400 | ✅ `400 invalid regex: …` |
+| API-3 | bounds | `limit=600` → clamped to 500 | ✅ `count:500` |
+| API-4 | bounds | `limit=0` → clamped to 1 | ✅ `count:1` |
+| API-5 | error | `partition=999` → clean not-found | 🐛 **KUI-BUG-1** (leaks S3 path) |
+| API-6 | state | purged items topic → empty + signal | 🐛 **KUI-BUG-2** (`count:0` but `watermark.high:25`) |
+| API-7 | error | non-existent topic → clean not-found | 🐛 **KUI-BUG-1** (leaks S3 path) |
+| UI-1 | state | purged topic in UI → clear empty state | 🐛 **KUI-BUG-2** ("25 messages" header + "No messages in this range") |
+| UI-2 | a11y | expand a message row via keyboard | 🐛 **KUI-BUG-3** (row not focusable) |
+| UI-3 | error | invalid offset in UI → error shown, no crash | ✅ error surfaced, no crash |
+| UI-4 | bounds | `Limit=600` → HTML `max=500`, backend clamps | ✅ no crash, ≤500 rendered |
+| UI-5 | persistence | value/key format persists across nav | ✅ `localStorage kotatsu:fmt` retained |
+| UI-6 | export | Export JSON → file downloads | ✅ `…pokemon-p0.json` |
+| UI-7 | filter | `value_contains=charizard` → filtered + flag | ✅ filtered rows + scan indicator |
+| UI-8 | groups | lazy-load consumer groups on topic page | ✅ list/state rendered |
+| UI-9 | schemas | schema detail page renders | ✅ type AVRO, fields, version selector |
+| UI-10 | pagination | topics list shows "x–y of N" | ✅ "1–21 of 21" |
+| UI-11 | pagination | rapid Next clicks → no stale results | ✅ Next disabled during fetch |
+| UI-12 | export | Export NDJSON → file downloads | ✅ `…pokemon-p0.ndjson` |
+| UI-13 | clipboard | Copy JSON → "Copied ✓" feedback | ✅ works (initial fail was a mis-targeted selector — false positive, retracted) |
+| UI-14 | perf | `limit=500` → renders without crash | 📝 **KUI-OBS-1** (503 rows, ~2 s, no virtualization) |
+| RES-001 | resilience | Kora down, uncached id → hex + `schemaId` + `error` | ✅ `{kind:"hex", schemaId:13, error:"schema id 13: schema registry is unreachable"}` (API + UI) |
+| RES-001t | resilience | Kora down → no multi-second hang (0.2.1 timeout) | ✅ ~0.01 s responses, 502 in 0.006 s — no 25-30 s hang |
+| RES-002 | resilience | `/schemas` down → clean error, no URL leak | ✅ `502 {"error":"schema registry is unreachable"}`, internal URL not leaked |
+| RES-cache | resilience | cached schema id still decodes during outage | ✅ pokemon (id 15) stays `avro` while Kora down |
+| RES-003 | resilience | decode resumes after Kora returns | ✅ TOPIC2 back to `avro` (id 13) after scale-up |
+
+> **Methodology note (rigour):** UI-2 and UI-13 first reported false positives because the
+> selector `table tbody tr` matched the *partitions* table, not the *messages* table (the
+> topic page renders several tables). Re-tested against the message row: row expansion **by
+> click works** and Copy JSON **works** (UI-13 retracted); keyboard inaccessibility **is
+> real** (UI-2 confirmed). Lesson recorded so the Playwright transposition targets the
+> message table explicitly.
+
+---
+
+## Defects (ISTQB format)
+
+### KUI-BUG-1 — Storage error responses leak internal S3 object paths — `P2` · filed as [kotatsu#63](https://github.com/Popsink/kotatsu/issues/63)
+- **Description:** `GET …/messages` for an out-of-range partition or a non-existent topic
+  returns a 404 whose body exposes the internal S3 layout instead of a user-meaningful
+  message.
+- **Steps:**
+  1. `GET /api/clusters/tansu/topics/<topic>/messages?partition=999&offset=earliest&limit=2`
+  2. `GET /api/clusters/tansu/topics/does.not.exist/messages?partition=0&offset=earliest&limit=2`
+- **Expected:** a clean, user-facing error, e.g. `"partition 999 out of range (topic has N
+  partitions)"` and `"topic 'does.not.exist' not found"`.
+- **Actual:** `{"error":"object not found: clusters/tansu/topics/…/partitions/0000000999/watermark.json"}`
+  — leaks bucket layout, zero-padded partition encoding, and the `watermark.json` filename.
+- **Notes:** the 0.2.1 "error hygiene" pass sanitized *schema-registry* errors (`api.rs:subject_err`)
+  but **not** *storage* errors, which still surface `StorageError`'s `to_string()`
+  (`storage/error.rs`, "object not found: {key}"). Same class as kotatsu#56, different code path.
+  Two problems in one: (a) information disclosure of internal structure; (b) non-actionable
+  message for the user/operator. A non-existent topic and an out-of-range partition are also
+  indistinguishable.
+- **Suggested fix:** map `StorageError::NotFound` to a sanitized API error in `api.rs` (distinguish
+  topic-not-found vs partition-out-of-range), and keep the raw key only in server logs.
+
+### KUI-BUG-2 — Phantom message count: purged records still advertise a non-zero count — `P2` · filed as [kotatsu#64](https://github.com/Popsink/kotatsu/issues/64)
+- **Description:** when a topic's S3 record batches are purged (retention) but `watermark.json`
+  survives, both the API and the UI keep advertising the old message count while serving zero
+  messages, with no error or empty-state explanation. (Same root cause as ANO-3 in
+  `kotatsu-integration.md`; this entry adds the UI-level confirmation.)
+- **Steps (API):** `GET …/topics/<purged-items-topic>/messages?partition=0&offset=earliest&limit=5`
+- **Steps (UI):** open `/topics/<purged-items-topic>` → From=earliest → Search.
+- **Expected:** the UI signals that records are unavailable/purged (or reconciles the count to
+  the readable range), rather than implying data exists.
+- **Actual:** API returns `count:0, scanned:0, exhausted:true, watermark:{low:0, high:25}`. The
+  UI header reads "partition 0 — low 0, high 25 (25 messages)" while the body shows
+  "No messages in this range" — a user sees "25 messages" yet can open none, with no hint why.
+- **Notes:** backend has no dedicated flag for "records gone, watermark stale"
+  (`storage/reader.rs`: empty base-offset listing returns `[]` while `watermark()` still reads
+  the persisted high). The frontend can only infer it from `count==0 && watermark.high>0`
+  (`pages/topics/[name].vue:324-326`).
+- **Suggested fix:** detect `count==0 && scanned==0 && watermark.high>low` in the backend and
+  return an explicit marker (e.g. `records_unavailable: true`), and render a distinct UI state
+  ("records for this range are no longer available").
+
+### KUI-BUG-3 — Message rows are not keyboard-accessible — `P2` (a11y)
+- **Description:** message rows expand on mouse click only. They carry no `tabindex` and no
+  `role`, so keyboard-only and screen-reader users cannot focus a row or open its detail
+  (full value, headers, schema link, Copy JSON).
+- **Steps:** load events on `/topics/…pokemon` → Tab toward the message table → attempt to focus
+  the first message row and press Enter.
+- **Expected:** rows are focusable (`tabindex="0"`, `role="button"`/`aria-expanded`) and toggle
+  on Enter/Space.
+- **Actual:** `tabindex=null`, `role=null`; `document.activeElement` stays on `<body>`; Enter
+  does nothing. Detail is reachable by mouse only.
+- **Notes:** `pages/topics/[name].vue:341-349` binds `@click` on the `<tr>` with no keyboard
+  handler. WCAG 2.1.1 (Keyboard) / 4.1.2 (Name, Role, Value).
+- **Suggested fix:** add `tabindex="0"`, `role="button"`, `:aria-expanded`, and a
+  `@keydown.enter.space.prevent` handler mirroring the click toggle.
+
+### KUI-BUG-4 — Consumer-groups load failure is rendered as "none" (error disguised as empty) — `P2` · filed as [kotatsu#66](https://github.com/Popsink/kotatsu/issues/66)
+- **Description:** on the topic page, the lazy-loaded "Consumer groups" panel shows `none` both
+  when a topic genuinely has no consumer groups **and** when the load request fails. A failure is
+  silently turned into a reassuring "no groups" state — same "invisible state" class as KUI-BUG-2.
+- **Steps (error-injection, Playwright):**
+  1. Open `/topics/…c197b708407.pokemon` (which has 1 real consumer group, `52f73d0a…`).
+  2. Intercept `**/api/clusters/*/topics/*/groups` and fulfill it with HTTP 500.
+  3. Click "Consumer groups".
+- **Expected:** the UI surfaces a load error (e.g. "couldn't load consumer groups").
+- **Actual:** the group vanishes and the UI shows **`none`** with **no error** — identical to a
+  topic that truly has zero groups. Confirmed live: normal load shows `52f73d0a…` + lag/offsets;
+  with the request failing, only `none` is shown.
+- **Impact:** an operator checking "is anything consuming this topic?" sees `none` and may
+  conclude the pipeline is broken (and act on it) when in fact the panel just failed to load —
+  a false negative on a monitoring-relevant signal.
+- **Notes:** `pages/topics/[name].vue` `loadGroups()` ~L41-52 does `catch { topicGroups.value = [] }`,
+  and the template renders `[]` as "none" (~L249) — indistinguishable from a successful empty result.
+- **Suggested fix:** keep a distinct error state in the catch branch (e.g. `topicGroups = 'error'`)
+  and render "couldn't load consumer groups" instead of "none".
+
+---
+
+## Observations (not defects)
+
+### KUI-OBS-1 — Large result sets are not virtualized — `P3`
+`limit=500` renders ~503 rows (plus per-row detail templates) with no virtual scrolling
+(`pages/topics/[name].vue` `v-for` over `records`); ~2 s to render and the page grows heavy as
+rows are expanded. Acceptable at 500 (the hard cap), but worth a note for UX/perf and a virtual
+list if the cap ever rises.
+
+### KUI-OBS-2 — Clipboard copy failures are swallowed silently — `P3` · filed as [kotatsu#65](https://github.com/Popsink/kotatsu/issues/65)
+Copy JSON works in normal conditions (secure context + permission → "Copied ✓"). But
+`pages/topics/[name].vue:175` does `catch {}` — if the Clipboard API rejects (no permission,
+insecure context, oversized payload) the user gets no feedback at all. Consider surfacing a
+"copy failed" hint.
+
+---
+
+## Resilience scenario — executed 2026-06-15 (all PASS)
+
+Kora was scaled to 0 replicas (with explicit user go-ahead), the outage path probed against an
+**uncached** schema id (`…E2E_TESTING_SOURCE_E2E_TOPIC2`, id 13), then Kora scaled back to 1:
+
+- **RES-001** — uncached id with Kora down → `{kind:"hex", schemaId:13, error:"schema id 13:
+  schema registry is unreachable"}`; the UI shows the hex payload + the "unreachable" warning and
+  stays alive (no blank page). **The 2026-06-11 ANO-1 FAIL is resolved in 0.2.1.**
+- **RES-001 (timing)** — responses returned in ~0.01 s; `/schemas` 502 in 0.006 s. **No 25-30 s
+  hang (ANO-2 resolved).** (Connection is refused fast since the Service has no endpoints; the
+  5 s timeout would also bound a true blackhole.)
+- **RES-002** — `/schemas` with Kora down → `502 {"error":"schema registry is unreachable"}`,
+  internal Kora URL **not** leaked.
+- **RES-cache** — pokemon (id 15, already resolved) kept decoding as `avro` during the outage —
+  confirms immutable-id schema caching.
+- **RES-003** — after scaling Kora back to 1, TOPIC2 decoded again as `avro` (id 13). Clean recovery.
+
+The environment was restored: Kora back at 1 replica, endpoints routing, `/schemas` returns its
+11 subjects.
+
+## Reproduction
+
+Scripts under `~/.kora-e2e-scratch/`: `deep-ui.mjs` (UI-1…7), `deep-ui2.mjs` (UI-8…14),
+`diag-expand2.mjs` (row-targeting fix for UI-2/UI-13). Screenshots `ui1-*`, `ui7-*`, `ui9-*`,
+`diag-expand.png`. API probes are plain `curl` against `https://kotatsu.ppsk.localhost/api`.

--- a/tests/e2e/test-cases.md
+++ b/tests/e2e/test-cases.md
@@ -1,4 +1,12 @@
-# Kora — End-to-End Test Case Catalogue
+# Kora — Schema Registry API Reference Catalogue
+
+> **📌 Scope note (read first):** this catalogue covers **Kora in isolation** — its
+> Schema Registry REST API. It largely overlaps the developer's own unit/integration
+> tests, so it is kept as a **reference annex**, not the primary QA deliverable. The
+> primary e2e work is the **Kora ↔ Kotatsu integration** suite in
+> [`kotatsu-integration.md`](./kotatsu-integration.md), which tests the live chain from
+> the outside (the layer unit tests don't cover). Use this file to look up Kora's
+> endpoints and error codes; use `kotatsu-integration.md` to test what users actually see.
 
 > **Status:** Living document — functional specification of expected behaviour, written
 > first; automation comes later (see issue *"QA: end-to-end test case catalogue"*).


### PR DESCRIPTION
## Summary

Follow-up to #45 — the integration catalogue commit was authored before the merge but never pushed, so it missed the PR. This brings:

- **`tests/e2e/kotatsu-integration.md`** — the primary e2e deliverable: 16 cases (`KKI-*`) over 4 scenarios (nominal decode, schema evolution, Kora outage resilience, Schemas tab), testing the live **Kora ↔ Kotatsu** chain black-box from the UI/API. `test-cases.md` and `first-batch.md` get scope notes repositioning them as the Kora-in-isolation reference.
- **First execution results (2026-06-11):** DEC 5/5 PASS · SCH 4/4 PASS · RES 2 PASS / 1 partial FAIL / 1 skipped · EVO blocked (the source database that produced the reference events no longer exists).

## Findings filed as issues

| Finding | Issue |
|---|---|
| Bare hex with no diagnostic when Kora is down (deployed kotatsu 0.1.0 predates the v0.2.0 error surfacing) | Popsink/data-plane#2650 |
| Registry HTTP client has no timeout → ~25–30 s hangs | Popsink/kotatsu#55 |
| Error messages leak internal registry routes/URLs | Popsink/kotatsu#56 |

## Also in this PR

- Scenario-3 blocker resolved and documented: drive the cluster through the Kind node's embedded kubectl (no local kubectl needed)
- Scenario-2 blocker documented: EVO needs a re-provisioned source pipeline or synthetic v2 events
- Fixed the subject-detail `jq` filter (actual response shape is `{subject, versions, latest:{…}}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)