### PR TITLE
feat: configurable default global compatibility level (env + Helm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ docker run -p 8080:8080 -e DATABASE_URL="postgres://user:pass@host:5432/kora" gh
 | `MAX_BODY_SIZE` | `16777216` | Maximum request body size in bytes |
 | `DB_POOL_MAX` | `20` | Maximum database connections |
 | `RUST_LOG` | `info` | Log level (`error`, `warn`, `info`, `debug`, `trace`) |
+| `DEFAULT_COMPATIBILITY` | *(unset)* | Default global compatibility level, re-applied to the global config on **every startup** — overwriting any runtime `PUT`/`DELETE /config` change to the global level. One of `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE`, `NONE`. Leave unset (default) to let the runtime API own the level (`BACKWARD` on a fresh install) |
 
 ## API
 

--- a/chart/README.md
+++ b/chart/README.md
@@ -123,6 +123,7 @@ resources:
 |---|---|---|
 | `kora.port` | `8080` | Listen port |
 | `kora.logLevel` | `info` | Log level (RUST_LOG) |
+| `kora.defaultCompatibility` | `""` | Default global compatibility level, re-applied to the global config on every startup (overwrites runtime `PUT`/`DELETE /config` changes). One of `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE`, `NONE`. Empty (default) lets the runtime API own it (`BACKWARD` on a fresh install) |
 | `kora.dbPoolMax` | `20` | Max DB connections |
 | `kora.maxBodySize` | `16777216` | Max request body (bytes) |
 | `kora.extraEnvVars` | `[]` | Extra env vars |

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -94,6 +94,10 @@ spec:
               value: {{ .Values.kora.maxBodySize | int | quote }}
             - name: RUST_LOG
               value: {{ .Values.kora.logLevel | quote }}
+            {{- if .Values.kora.defaultCompatibility }}
+            - name: DEFAULT_COMPATIBILITY
+              value: {{ .Values.kora.defaultCompatibility | quote }}
+            {{- end }}
             {{- if .Values.kora.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.kora.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -39,6 +39,7 @@ image:
 ## @param kora.dbPoolMax Maximum database connections in pool
 ## @param kora.maxBodySize Maximum request body size in bytes
 ## @param kora.logLevel Log level (RUST_LOG, e.g. info, debug, kora=trace)
+## @param kora.defaultCompatibility Default global compatibility level, re-applied to the global config on every startup (overwrites runtime PUT/DELETE /config changes; empty = runtime API owns it, BACKWARD on a fresh install). One of: BACKWARD, BACKWARD_TRANSITIVE, FORWARD, FORWARD_TRANSITIVE, FULL, FULL_TRANSITIVE, NONE
 ## @param kora.extraEnvVars Array with extra environment variables
 ## @param kora.extraEnvVarsCM Name of existing ConfigMap containing extra env vars
 ## @param kora.extraEnvVarsSecret Name of existing Secret containing extra env vars
@@ -47,6 +48,7 @@ kora:
   dbPoolMax: 20
   maxBodySize: 16777216
   logLevel: "info"
+  defaultCompatibility: ""
   extraEnvVars: []
   extraEnvVarsCM: ""
   extraEnvVarsSecret: ""

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,8 @@ use figment::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::api::compatibility::COMPATIBILITY_LEVELS;
+
 // -- Types --
 
 /// Top-level configuration for the Kora server.
@@ -42,6 +44,14 @@ pub struct KoraConfig {
     /// Maximum number of database connections in the pool.
     #[serde(default = "default_db_pool_max")]
     pub db_pool_max: u32,
+    /// Default global schema compatibility level. When set, it is reconciled into
+    /// the global config row (`subject IS NULL`) on every startup — the declared
+    /// default is the source of truth, overwriting any runtime `PUT`/`DELETE
+    /// /config` change to the global level. When unset (or blank), the stored
+    /// level is kept (built-in default `BACKWARD`). Validated on load against
+    /// `COMPATIBILITY_LEVELS`.
+    #[serde(default)]
+    pub default_compatibility: Option<String>,
 }
 
 // -- Impls --
@@ -59,6 +69,7 @@ impl Default for KoraConfig {
             port: default_port(),
             max_body_size: default_max_body_size(),
             db_pool_max: default_db_pool_max(),
+            default_compatibility: None,
         }
     }
 }
@@ -67,15 +78,18 @@ impl KoraConfig {
     /// Load configuration from defaults and environment variables.
     ///
     /// Recognized env vars: `DATABASE_URL`, `DB_HOST`, `DB_PORT`, `DB_USER`,
-    /// `DB_PASSWORD`, `DB_NAME`, `HOST`, `PORT`, `MAX_BODY_SIZE`, `DB_POOL_MAX`.
+    /// `DB_PASSWORD`, `DB_NAME`, `HOST`, `PORT`, `MAX_BODY_SIZE`, `DB_POOL_MAX`,
+    /// `DEFAULT_COMPATIBILITY`.
     ///
     /// When `DATABASE_URL` is empty, it is composed from the `DB_*` components
-    /// (with the user/password percent-encoded).
+    /// (with the user/password percent-encoded). A blank `DEFAULT_COMPATIBILITY`
+    /// is treated as unset.
     ///
     /// # Errors
     ///
-    /// Returns an error if values cannot be parsed, or if neither `DATABASE_URL`
-    /// nor a complete `DB_*` set (`DB_HOST`, `DB_USER`, `DB_NAME`) is provided.
+    /// Returns an error if values cannot be parsed, if `DEFAULT_COMPATIBILITY` is
+    /// not a known compatibility level, or if neither `DATABASE_URL` nor a
+    /// complete `DB_*` set (`DB_HOST`, `DB_USER`, `DB_NAME`) is provided.
     pub fn load() -> Result<Self, Box<figment::Error>> {
         let mut cfg: Self = Figment::from(Serialized::defaults(Self::default()))
             .merge(Env::raw().only(&[
@@ -92,6 +106,24 @@ impl KoraConfig {
             ]))
             .extract()
             .map_err(Box::new)?;
+
+        // Read DEFAULT_COMPATIBILITY directly rather than through figment: figment
+        // coerces bool/numeric-looking strings (e.g. "true", "1") to non-string
+        // types and would fail with an opaque error before our check runs. A blank
+        // or whitespace-only value is treated as unset; otherwise the level is
+        // validated so a typo fails fast at boot with an actionable message.
+        cfg.default_compatibility = std::env::var("DEFAULT_COMPATIBILITY")
+            .ok()
+            .map(|v| v.trim().to_owned())
+            .filter(|v| !v.is_empty());
+        if let Some(level) = &cfg.default_compatibility
+            && !COMPATIBILITY_LEVELS.contains(&level.as_str())
+        {
+            return Err(Box::new(figment::Error::from(format!(
+                "DEFAULT_COMPATIBILITY is invalid: {level}; must be one of: {}",
+                COMPATIBILITY_LEVELS.join(", ")
+            ))));
+        }
 
         if cfg.database_url.is_empty() {
             let mut missing = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,21 @@ async fn main() {
         .await
         .expect("failed to connect to database");
 
+    // Reconcile the declaratively-configured default compatibility level into the
+    // global config row: DEFAULT_COMPATIBILITY is the source of truth on every
+    // startup, overwriting any runtime PUT/DELETE /config change to the global
+    // level. Per-subject overrides are untouched.
+    if let Some(applied) =
+        storage::apply_startup_config(&pool, cfg.default_compatibility.as_deref())
+            .await
+            .expect("failed to reconcile global compatibility level")
+    {
+        tracing::info!(
+            compatibility = %applied,
+            "reconciled global compatibility from DEFAULT_COMPATIBILITY"
+        );
+    }
+
     let app = api::router(pool, metrics_handle, cfg.max_body_size);
     let addr = format!("{}:{}", cfg.host, cfg.port);
     let listener = TcpListener::bind(&addr)

--- a/src/storage/compatibility.rs
+++ b/src/storage/compatibility.rs
@@ -57,6 +57,27 @@ pub async fn set_global_level(
     .await
 }
 
+/// Reconcile the global compatibility level to `level`, returning the new value.
+///
+/// Unconditionally overwrites the global row (`subject IS NULL`); used at startup
+/// to make a declaratively-configured default (`DEFAULT_COMPATIBILITY`) the source
+/// of truth on every boot. Leaves `normalize` and all per-subject overrides
+/// untouched.
+///
+/// # Errors
+///
+/// Returns a database error on connection failure.
+pub async fn reconcile_global_level(pool: &PgPool, level: &str) -> Result<String, sqlx::Error> {
+    sqlx::query_scalar::<_, String>(
+        r"UPDATE config SET compatibility_level = $1, updated_at = now()
+          WHERE subject IS NULL
+          RETURNING compatibility_level",
+    )
+    .bind(level)
+    .fetch_one(pool)
+    .await
+}
+
 /// Set the per-subject compatibility level (upsert). Returns the new value.
 ///
 /// # Errors

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -26,3 +26,28 @@ pub async fn create_pool(database_url: &str, max_connections: u32) -> Result<PgP
 
     Ok(pool)
 }
+
+// -- Startup reconciliation --
+
+/// Apply declarative startup configuration to the database. Idempotent and safe
+/// to run on every boot.
+///
+/// When `default_compatibility` is set, reconciles the global compatibility level
+/// (`subject IS NULL`) to that value and returns it (for the caller to log).
+/// When `None`, it is a no-op returning `None`. Per-subject overrides are never
+/// touched.
+///
+/// # Errors
+///
+/// Returns a database error on connection failure.
+pub async fn apply_startup_config(
+    pool: &PgPool,
+    default_compatibility: Option<&str>,
+) -> Result<Option<String>, sqlx::Error> {
+    match default_compatibility {
+        Some(level) => Ok(Some(
+            compatibility::reconcile_global_level(pool, level).await?,
+        )),
+        None => Ok(None),
+    }
+}

--- a/tests/api_compatibility_config.rs
+++ b/tests/api_compatibility_config.rs
@@ -302,3 +302,137 @@ async fn get_subject_compatibility_accepts_python_style_default_to_global() {
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body["compatibilityLevel"], "BACKWARD");
 }
+
+// -- Declarative startup default (issue #47) --
+//
+// `storage::apply_startup_config` is what the startup path (main.rs) calls when
+// `DEFAULT_COMPATIBILITY` is set; it delegates to `reconcile_global_level`. These
+// tests mutate the shared global config row, so — like the global `/config` tests
+// above — they are `#[serial]` and restore `BACKWARD`. This binary is the only one
+// that touches the global row, so `#[serial]` is sufficient to serialize them.
+
+/// A configured default is the source of truth: startup reconciliation overwrites
+/// whatever global level was stored (e.g. a prior runtime change).
+#[tokio::test]
+#[serial]
+async fn apply_startup_config_overrides_stored_global_level() {
+    let pool = common::pool().await;
+
+    // A previously-stored level (e.g. set by an operator via PUT /config).
+    kora::storage::compatibility::set_global_level(&pool, "FORWARD", false)
+        .await
+        .unwrap();
+
+    let applied = kora::storage::apply_startup_config(&pool, Some("NONE"))
+        .await
+        .unwrap();
+    assert_eq!(applied.as_deref(), Some("NONE"));
+
+    let stored = kora::storage::compatibility::get_global_level(&pool)
+        .await
+        .unwrap();
+    assert_eq!(stored, "NONE", "the declared default must win on startup");
+
+    // Restore the suite default.
+    kora::storage::compatibility::set_global_level(&pool, "BACKWARD", false)
+        .await
+        .unwrap();
+}
+
+/// With no configured default, startup is a no-op and leaves the stored level alone.
+#[tokio::test]
+#[serial]
+async fn apply_startup_config_without_default_is_noop() {
+    let pool = common::pool().await;
+
+    kora::storage::compatibility::set_global_level(&pool, "FULL", false)
+        .await
+        .unwrap();
+
+    let applied = kora::storage::apply_startup_config(&pool, None)
+        .await
+        .unwrap();
+    assert_eq!(applied, None);
+
+    let stored = kora::storage::compatibility::get_global_level(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        stored, "FULL",
+        "no declared default must leave the stored level untouched"
+    );
+
+    // Restore the suite default.
+    kora::storage::compatibility::set_global_level(&pool, "BACKWARD", false)
+        .await
+        .unwrap();
+}
+
+/// Startup reconciliation never clobbers per-subject overrides
+/// (the issue's explicit requirement).
+#[tokio::test]
+#[serial]
+async fn apply_startup_config_preserves_subject_overrides() {
+    let pool = common::pool().await;
+    let subject = format!("startup-compat-{}", uuid::Uuid::new_v4());
+
+    kora::storage::compatibility::set_subject_level(&pool, &subject, "FORWARD", false)
+        .await
+        .unwrap();
+
+    kora::storage::apply_startup_config(&pool, Some("FULL"))
+        .await
+        .unwrap();
+
+    let subject_level = kora::storage::compatibility::get_subject_level(&pool, &subject)
+        .await
+        .unwrap();
+    assert_eq!(
+        subject_level.as_deref(),
+        Some("FORWARD"),
+        "per-subject override must survive startup reconciliation"
+    );
+
+    let global = kora::storage::compatibility::get_global_level(&pool)
+        .await
+        .unwrap();
+    assert_eq!(global, "FULL");
+
+    // Restore the suite default.
+    kora::storage::compatibility::set_global_level(&pool, "BACKWARD", false)
+        .await
+        .unwrap();
+}
+
+/// Reconcile changes only the compatibility level — it leaves the global
+/// `normalize` flag intact (`DEFAULT_COMPATIBILITY` governs the level only).
+#[tokio::test]
+#[serial]
+async fn reconcile_global_level_preserves_normalize_flag() {
+    let pool = common::pool().await;
+
+    // Configure the global row with normalize = true via the regular API path.
+    kora::storage::compatibility::set_global_level(&pool, "BACKWARD", true)
+        .await
+        .unwrap();
+
+    kora::storage::compatibility::reconcile_global_level(&pool, "FULL")
+        .await
+        .unwrap();
+
+    let normalize =
+        sqlx::query_scalar::<_, Option<bool>>("SELECT normalize FROM config WHERE subject IS NULL")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        normalize,
+        Some(true),
+        "reconcile must not reset the normalize flag"
+    );
+
+    // Restore the suite default.
+    kora::storage::compatibility::set_global_level(&pool, "BACKWARD", false)
+        .await
+        .unwrap();
+}

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -14,6 +14,7 @@ fn config_defaults_applied() {
     assert_eq!(cfg.port, 8080);
     assert!(cfg.database_url.is_empty());
     assert_eq!(cfg.db_pool_max, 20);
+    assert_eq!(cfg.default_compatibility, None);
 }
 
 #[test]
@@ -72,6 +73,90 @@ fn load_errors_when_neither_url_nor_components_provided() {
 
         assert!(msg.contains("DATABASE_URL"), "{msg}");
         assert!(msg.contains("DB_HOST"), "{msg}");
+        Ok(())
+    });
+}
+
+#[test]
+fn load_accepts_valid_default_compatibility() {
+    Jail::expect_with(|jail| {
+        jail.set_env("DATABASE_URL", "postgres://from-env/db");
+        jail.set_env("DEFAULT_COMPATIBILITY", "FULL");
+
+        let cfg = KoraConfig::load().expect("valid level should load");
+
+        assert_eq!(cfg.default_compatibility.as_deref(), Some("FULL"));
+        Ok(())
+    });
+}
+
+#[test]
+fn load_rejects_invalid_default_compatibility() {
+    Jail::expect_with(|jail| {
+        jail.set_env("DATABASE_URL", "postgres://from-env/db");
+        jail.set_env("DEFAULT_COMPATIBILITY", "SIDEWAYS");
+
+        let err = KoraConfig::load().expect_err("invalid level should fail load");
+        let msg = err.to_string();
+
+        assert!(msg.contains("DEFAULT_COMPATIBILITY"), "{msg}");
+        assert!(msg.contains("SIDEWAYS"), "{msg}");
+        Ok(())
+    });
+}
+
+#[test]
+fn load_treats_empty_default_compatibility_as_unset() {
+    Jail::expect_with(|jail| {
+        jail.set_env("DATABASE_URL", "postgres://from-env/db");
+        jail.set_env("DEFAULT_COMPATIBILITY", "");
+
+        let cfg = KoraConfig::load().expect("empty level should be treated as unset");
+
+        assert_eq!(cfg.default_compatibility, None);
+        Ok(())
+    });
+}
+
+#[test]
+fn load_treats_whitespace_default_compatibility_as_unset() {
+    Jail::expect_with(|jail| {
+        jail.set_env("DATABASE_URL", "postgres://from-env/db");
+        jail.set_env("DEFAULT_COMPATIBILITY", "   ");
+
+        let cfg = KoraConfig::load().expect("whitespace-only should be treated as unset");
+
+        assert_eq!(cfg.default_compatibility, None);
+        Ok(())
+    });
+}
+
+#[test]
+fn load_trims_default_compatibility() {
+    Jail::expect_with(|jail| {
+        jail.set_env("DATABASE_URL", "postgres://from-env/db");
+        jail.set_env("DEFAULT_COMPATIBILITY", "  FULL  ");
+
+        let cfg = KoraConfig::load().expect("padded valid level should load");
+
+        assert_eq!(cfg.default_compatibility.as_deref(), Some("FULL"));
+        Ok(())
+    });
+}
+
+#[test]
+fn load_rejects_bool_like_default_compatibility_with_friendly_error() {
+    // A YAML-unquoted scalar like `true`/`123` must still reach the actionable
+    // "must be one of" validation rather than an opaque type-coercion error.
+    Jail::expect_with(|jail| {
+        jail.set_env("DATABASE_URL", "postgres://from-env/db");
+        jail.set_env("DEFAULT_COMPATIBILITY", "true");
+
+        let err = KoraConfig::load().expect_err("bool-like value should fail load");
+        let msg = err.to_string();
+
+        assert!(msg.contains("DEFAULT_COMPATIBILITY"), "{msg}");
+        assert!(msg.contains("must be one of"), "{msg}");
         Ok(())
     });
 }


### PR DESCRIPTION
## Summary

Implements #47: a declarative default for the **global** schema compatibility level, so GitOps deployments are deterministic instead of always starting on the seeded `BACKWARD`.

- **Env var** `DEFAULT_COMPATIBILITY`, parsed in `KoraConfig::load()` and validated against `COMPATIBILITY_LEVELS` (read via `std::env::var` so bool/numeric-looking typos still get the actionable error; blank/whitespace treated as unset).
- **Startup reconciliation**: when set, the global config row (`subject IS NULL`) is reconciled to that level on every boot — the declared value is the source of truth, **without** clobbering per-subject overrides. The `normalize` flag is left intact.
- **Helm value** `kora.defaultCompatibility`, emitted as the env var only when non-empty.

## Design decision (issue's open question)

Resolved as **reconcile-on-startup** (most GitOps-friendly): a set value overwrites runtime `PUT`/`DELETE /config` changes to the global level on every restart/rollout. This is documented in `README.md`, `chart/README.md`, the Helm `@param`, and the config doc-comment. No DB migration needed — `reconcile_global_level` is an `UPDATE` on the always-present global row, consistent with `set_global_level`/`set_global_mode`.

## Tests

- `tests/config.rs`: valid / invalid / empty / whitespace / bool-like parsing and validation.
- `tests/api_compatibility_config.rs` (`#[serial]`, co-located with the other global-row tests): reconcile overrides stored value, no-op when unset, per-subject override preserved, `normalize` preserved.
- Full suite: **322 passed / 0 failed**. `cargo fmt`, `cargo clippy -D pedantic`, `helm lint` all green.

Closes #47
